### PR TITLE
Enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.3.61'
-    id 'org.jetbrains.intellij' version '0.4.15'
+    id 'org.jetbrains.intellij' version '0.4.21'
 }
 
 group 'com.andrewbrookins.idea.wrap'
@@ -19,7 +19,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2019.3.1'
+    version '2020.2'
 }
 patchPluginXml {
     changeNotes """

--- a/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
@@ -10,35 +10,35 @@ import java.util.regex.Pattern
  * This code was inspired by Nir Soffer's codewrap library: * https://pypi.python.org/pypi/codewrap/
  */
 class CodeWrapper(
-        val commentRegex: Regex = "(/\\*+|\\*/|\\*|\\.|#+|//+|;+)?".toRegex(),
+    private val commentRegex: Regex = "(/\\*+|\\*/|\\*|\\.|#+|//+|;+)?".toRegex(),
 
-        val newlineRegex: Regex = "(\\r?\\n)".toRegex(),
+    private val newlineRegex: Regex = "(\\r?\\n)".toRegex(),
 
-        val htmlSeparatorsRegex: Regex = "<[pP]>|<[bB][rR] ?/?>".toRegex(),
+    private val htmlSeparatorsRegex: Regex = "<[pP]>|<[bB][rR] ?/?>".toRegex(),
 
-        // A string that contains only two new lines demarcates a paragraph.
-        val paragraphSeparatorPattern: Pattern = Pattern.compile(
-                "($newlineRegex)\\s*$commentRegex\\s*($htmlSeparatorsRegex)?$newlineRegex"),
+    // A string that contains only two new lines demarcates a paragraph.
+    private val paragraphSeparatorPattern: Pattern = Pattern.compile(
+            "($newlineRegex)\\s*$commentRegex\\s*($htmlSeparatorsRegex)?$newlineRegex"),
 
-        val tabPlaceholder: String = "☃",
+    private val tabPlaceholder: String = "☃",
 
-        // A string containing a comment or empty space is considered an indent.
-        val indentRegex: String = "^(\\s|$tabPlaceholder)*$commentRegex\\s*($htmlSeparatorsRegex)?",
-        val indentPattern: Pattern = Pattern.compile(indentRegex),
+    // A string containing a comment or empty space is considered an indent.
+    private val indentRegex: String = "^(\\s|$tabPlaceholder)*$commentRegex\\s*($htmlSeparatorsRegex)?",
+    private val indentPattern: Pattern = Pattern.compile(indentRegex),
 
-        // New lines appended to text during wrapping will use this character.
-        // NOTE: Intellij always uses \n character for new lines and UI
-        // components will fail assertion checks if they receive \r\n. The
-        // correct line ending is used when saving the file.
-        val lineSeparator: String = "\n",
+    // New lines appended to text during wrapping will use this character.
+    // NOTE: Intellij always uses \n character for new lines and UI
+    // components will fail assertion checks if they receive \r\n. The
+    // correct line ending is used when saving the file.
+    private val lineSeparator: String = "\n",
 
-        // The column width to wrap text to.
-        val width: Int = 72,
+    // The column width to wrap text to.
+    val width: Int = 72,
 
-        // The number of display columns that a tab character should represent.
-        val tabWidth: Int = 4,
+    // The number of display columns that a tab character should represent.
+    val tabWidth: Int = 4,
 
-        val useMinimumRaggedness: Boolean = false) {
+    val useMinimumRaggedness: Boolean = false) {
 
     /**
      * Data about a line that has been split into two pieces: the indent portion
@@ -75,7 +75,7 @@ class CodeWrapper(
         val result = StringBuilder()
         val paragraphMatcher = paragraphSeparatorPattern.matcher(textWithTabPlaceholders)
         val textLength = textWithTabPlaceholders.length
-        var location: Int = 0
+        var location = 0
 
         while (paragraphMatcher.find()) {
             val paragraph = textWithTabPlaceholders.substring(location, paragraphMatcher.start())
@@ -95,9 +95,7 @@ class CodeWrapper(
             builtResult += lineSeparator
         }
 
-        val resultWithTabs = builtResult.replace(expandedTabPlaceholder, "\t")
-
-        return resultWithTabs
+        return builtResult.replace(expandedTabPlaceholder, "\t")
     }
 
     /**
@@ -110,7 +108,7 @@ class CodeWrapper(
      * *
      * @return text reflowed to chosen width
      */
-    fun wrapParagraph(paragraph: String): String {
+    private fun wrapParagraph(paragraph: String): String {
         val resultBuilder = StringBuilder()
         val emptyCommentPattern = Pattern.compile("$indentRegex\$", Pattern.MULTILINE)
         val emptyCommentMatcher = emptyCommentPattern.matcher(paragraph)
@@ -175,7 +173,7 @@ class CodeWrapper(
      *
      * @return array of lines
      */
-    fun breakToLinesOfChosenWidth(text:String):MutableList<String> {
+    private fun breakToLinesOfChosenWidth(text:String):MutableList<String> {
         val firstLineIndent = splitOnIndent(text).indent
         val firstLineIsCommentOpener = firstLineIndent.matches("\\s*/\\*+\\s*".toRegex())
         val indentIsWhiteSpaceOnly = firstLineIndent.matches("(\\s|$tabPlaceholder)*".toRegex())
@@ -202,7 +200,7 @@ class CodeWrapper(
             }
         }
 
-        for (i in 0..length - 1) {
+        for (i in 0 until length) {
             val line = lines[i]
             var lineIndent = firstLineIndent
 
@@ -226,7 +224,7 @@ class CodeWrapper(
      * *
      * @return one line of text
      */
-    fun unwrap(text: String): String {
+    private fun unwrap(text: String): String {
         if (text.isEmpty()) {
             return text
         }
@@ -236,9 +234,9 @@ class CodeWrapper(
         var lastLineWasCarriageReturn = false
         val length = lines.size
 
-        for (i in 0..length - 1) {
+        for (i in 0 until length) {
             val line = lines[i]
-            val unindentedLine = splitOnIndent(line).rest.trim({ it <= ' ' })
+            val unindentedLine = splitOnIndent(line).rest.trim { it <= ' ' }
 
             if (line.isEmpty()) {
                 // Ignore a line that was just a carriage return/new line.

--- a/src/main/java/com/andrewbrookins/idea/wrap/WrapParagraphAction.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/WrapParagraphAction.kt
@@ -15,9 +15,9 @@ import com.intellij.openapi.util.TextRange
 
 
 data class TextData(val lineStart: Int, val lineEnd: Int, val lineData: CodeWrapper.LineData)
-fun getTextAtLine(document: Document, wrapper: CodeWrapper, offset: Int): TextData {
-    val lineStart = document.getLineStartOffset(offset)
-    val lineEnd = document.getLineEndOffset(offset)
+fun getTextAtLine(document: Document, wrapper: CodeWrapper, lineNum: Int): TextData {
+    val lineStart = document.getLineStartOffset(lineNum)
+    val lineEnd = document.getLineEndOffset(lineNum)
     val text = document.getText(TextRange(lineStart, lineEnd))
     return TextData(lineStart, lineEnd, wrapper.splitOnIndent(text))
 }
@@ -34,6 +34,7 @@ class WrapParagraphAction : EditorAction(WrapHandler()) {
 
     private class WrapHandler : EditorActionHandler() {
         override fun execute(editor: Editor, dataContext: DataContext?) {
+            super.execute(editor, dataContext)
             ApplicationManager.getApplication().runWriteAction(object : Runnable {
                 override fun run() {
                     val project = LangDataKeys.PROJECT.getData(dataContext!!)

--- a/src/main/java/com/andrewbrookins/idea/wrap/WrapParagraphAction.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/WrapParagraphAction.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.LangDataKeys
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.actionSystem.EditorAction
@@ -95,9 +94,5 @@ class WrapParagraphAction : EditorAction(WrapHandler()) {
                 }
             })
         }
-    }
-
-    companion object {
-        private val log = Logger.getInstance(WrapParagraphAction::class.java)
     }
 }

--- a/src/main/java/com/andrewbrookins/idea/wrap/WrappingAlgorithms.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/WrappingAlgorithms.kt
@@ -121,14 +121,14 @@ fun wrapMinimumRaggedness(text: String, width: Int): Array<String> {
     var offset = 0
 
     while (true) {
-        val r = Math.min(n.toDouble(), 2.0.pow((i + 1.0))).toInt()
-        val edge = 2.0.pow(i.toDouble()) + offset
+        val r = Math.min(n, 2 shl i)
+        val edge = (1 shl i) + offset
         // Python ranges drop the last item, but Kotlin's preserve it -- so we subtract one.
-        smawk(((0 + offset) until edge.toInt()).toMutableList(), (edge.toInt() until (r + offset)).toMutableList().toTypedArray())
+        smawk(((0 + offset) until edge).toMutableList(), (edge until (r + offset)).toMutableList().toTypedArray())
         val x = minima[(r - 1 + offset)]
         var costGreaterThanOrEqualToMinima = false
 
-        for (j in 2.0.pow(i.toDouble()).toInt() until r - 1) {
+        for (j in 1 shl i until r - 1) {
             val y = cost(j + offset, r - 1 + offset)
             if (y <= x) {
                 n -= j

--- a/src/main/java/com/andrewbrookins/idea/wrap/WrappingAlgorithms.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/WrappingAlgorithms.kt
@@ -1,12 +1,13 @@
 package com.andrewbrookins.idea.wrap
 
+import kotlin.math.pow
+
 /**
  * Helper to wrap a string using a greedy algorithm.
  *
  * Adapted from Apache Commons Lang.
  */
 fun wrapGreedy(str: String, wrapLength: Int, lineSeparator: String): String {
-    val newLineStr = lineSeparator
     val inputLineLength = str.length
     val space = ' '
     val wrappedLine = StringBuffer(inputLineLength + 32)
@@ -24,13 +25,13 @@ fun wrapGreedy(str: String, wrapLength: Int, lineSeparator: String): String {
 
         if (spaceToWrapAt >= offset) {
             wrappedLine.append(str.substring(offset, spaceToWrapAt))
-            wrappedLine.append(newLineStr)
+            wrappedLine.append(lineSeparator)
             offset = spaceToWrapAt + 1
         } else {
             spaceToWrapAt = str.indexOf(space, wrapLength + offset)
             if (spaceToWrapAt >= 0) {
                 wrappedLine.append(str.substring(offset, spaceToWrapAt))
-                wrappedLine.append(newLineStr)
+                wrappedLine.append(lineSeparator)
                 offset = spaceToWrapAt + 1
             } else {
                 wrappedLine.append(str.substring(offset))
@@ -51,27 +52,26 @@ fun wrapGreedy(str: String, wrapLength: Int, lineSeparator: String): String {
 fun wrapMinimumRaggedness(text: String, width: Int): Array<String> {
     val words = text.split(' ')
     val count = words.size
-    var offsets = arrayListOf(0.0)
+    val offsets = arrayListOf(0.0)
     for (w in words) {
         offsets.add(offsets[offsets.size - 1] + w.length)
     }
 
-    var minima = arrayOf(0.0) + Array(count, { Math.pow(10.0, 20.0) })
-    var breaks = Array(count + 1, { 0 })
+    val minima = arrayOf(0.0) + Array(count, { Math.pow(10.0, 20.0) })
+    val breaks = Array(count + 1, { 0 })
 
     fun cost(i: Int, j: Int): Double {
         val w = offsets[j] - offsets[i] + j - i - 1
         if (w > width) {
-            return Math.pow(10.0, 10.0) * (w - width)
+            return 10.0.pow(10.0) * (w - width)
         }
-        return minima[i] + Math.pow((width - w), 2.0)
+        return minima[i] + (width - w).pow(2.0)
     }
 
     fun smawk(rows: MutableList<Int>, columns: Array<Int>) {
-        var stack = arrayListOf<Int>()
+        val stack = arrayListOf<Int>()
         var i = 0
-        var j: Int
-        var length = rows.size
+        val length = rows.size
         while (i < length) {
             if (stack.size > 0) {
                 val c = columns[stack.size - 1]
@@ -95,7 +95,7 @@ fun wrapMinimumRaggedness(text: String, width: Int): Array<String> {
         }
 
         i = 0
-        j = 0
+        var j = 0
         var end: Int
         while (j < columns.size) {
             if (j + 1 < columns.size) {
@@ -121,15 +121,14 @@ fun wrapMinimumRaggedness(text: String, width: Int): Array<String> {
     var offset = 0
 
     while (true) {
-        val r = Math.min(n.toDouble(), Math.pow(2.0, (i + 1.0))).toInt()
-        val edge = Math.pow(2.0, i.toDouble()) + offset
+        val r = Math.min(n.toDouble(), 2.0.pow((i + 1.0))).toInt()
+        val edge = 2.0.pow(i.toDouble()) + offset
         // Python ranges drop the last item, but Kotlin's preserve it -- so we subtract one.
-        smawk((0 + offset).rangeTo(edge.toInt() - 1).toMutableList(), edge.toInt().rangeTo((r + offset).toInt() - 1).toMutableList().toTypedArray())
-        val x = minima[(r - 1 + offset).toInt()]
+        smawk(((0 + offset) until edge.toInt()).toMutableList(), (edge.toInt() until (r + offset)).toMutableList().toTypedArray())
+        val x = minima[(r - 1 + offset)]
         var costGreaterThanOrEqualToMinima = false
 
-        // Python ranges drop the last item, but Kotlin's preserve it -- so we subtract one.
-        for (j in Math.pow(2.0, i.toDouble()).toInt().rangeTo(r - 1 - 1)) {
+        for (j in 2.0.pow(i.toDouble()).toInt() until r - 1) {
             val y = cost(j + offset, r - 1 + offset)
             if (y <= x) {
                 n -= j
@@ -152,7 +151,7 @@ fun wrapMinimumRaggedness(text: String, width: Int): Array<String> {
     while (j > 0) {
         i = breaks[j]
         // Python ranges drop the last item, but Kotlin's preserve it -- so we subtract one.
-        lines.add(words.slice(i..j - 1).joinToString(" "))
+        lines.add(words.slice(i until j).joinToString(" "))
         j = i
     }
     return lines.reversed().toTypedArray()

--- a/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
+++ b/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
@@ -13,30 +13,29 @@ class CodeWrapperTests {
         val original = "// This is my text.\n// This is my text.\n"
         val text = wrapper.wrap(original)
         assertEquals("// This is my text. This is my text.\n", text)
-
     }
 
     @Test
     fun testWrapsToColumnWidthComment() {
-        val text = wrapper.wrap("// a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n")
+        val text = wrapper.wrap("// aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n")
 
-        val expected = "// a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n// a a a a a a a a a a a a a a a a a a a a a\n"
+        val expected = "// aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n// a a a a a a a a a a a a a a a a a a a a a a a a\n"
         assertEquals(expected, text)
     }
 
     @Test
     fun testWrapsToColumnWidthCStyleOpeningComment() {
-        val text = wrapper.wrap("/** a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n*/")
+        val text = wrapper.wrap("/** aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n*/")
 
-        val expected = "/** a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n * a a a a a a\n*/"
+        val expected = "/** aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n * aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n * a a a a a a a a a a\n*/"
         assertEquals(expected, text)
     }
 
     @Test
     fun testWrapsToColumnWidthNoComment() {
-        val text = wrapper.wrap("a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n")
+        val text = wrapper.wrap("aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\n")
 
-        val expected = "a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\na a a a a a a a a a a a a a a a a a a a\n"
+        val expected = "aa a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\na a a a a a a a a a a a a a a a a a a a a a a a\n"
         assertEquals(expected, text)
     }
 
@@ -44,19 +43,19 @@ class CodeWrapperTests {
     fun testWrapOneLongLine() {
         val text = wrapper.wrap("// This is my very long line of text. This is my very long line of text. This is my very long line of text.\n")
 
-        val expected = "// This is my very long line of text. This is my very long line of text. This is\n// my very long line of text.\n"
+        val expected = "// This is my very long line of text. This is my very long line of text.\n// This is my very long line of text.\n"
         assertEquals(expected, text)
     }
 
     @Test
     fun testWrapRetainsSeparateParagraphs() {
         val text = wrapper.wrap("// This is my very long line of text. This is my very long line of text. This is my very long line of text.\n\n// This is a second paragraph.\n")
-        val expected = "// This is my very long line of text. This is my very long line of text. This is\n// my very long line of text.\n\n// This is a second paragraph.\n"
+        val expected = "// This is my very long line of text. This is my very long line of text.\n// This is my very long line of text.\n\n// This is a second paragraph.\n"
         assertEquals(expected, text)
     }
 
     @Test
-    fun testWrapDoesNotCombineTwoShortLines() {
+    fun testWrapCombineTwoShortLines() {
         val text = wrapper.wrap("// This is my text.\n// This is my text.")
         assertEquals("// This is my text. This is my text.", text)
     }
@@ -64,34 +63,41 @@ class CodeWrapperTests {
     @Test
     fun testWrapFillsMultiLineOpener() {
         val text = wrapper.wrap("/** This is my text This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.")
-        assertEquals("/** This is my text This is my long multi-line comment opener text. More text\n * please. This is yet another bunch of text in my test comment, so I will get\n * multiple lines in the comment.", text)
+        assertEquals("/** This is my text This is my long multi-line comment opener text. More\n * text please. This is yet another bunch of text in my test comment, so I\n * will get multiple lines in the comment.", text)
     }
 
     @Test
     fun testWrapFillsMultiLineOpenerBeginningSpace() {
         val text = wrapper.wrap("  /* This is my text This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment. */")
-        assertEquals("  /* This is my text This is my long multi-line comment opener text. More text\n   * please. This is yet another bunch of text in my test comment, so I will get\n   * multiple lines in the comment. */", text)
+        assertEquals("  /* This is my text This is my long multi-line comment opener text. More\n   * text please. This is yet another bunch of text in my test comment, so I\n   * will get multiple lines in the comment. */", text)
     }
 
     @Test
     fun testWrapPreservesEmptyCommentLines() {
         val originalText = "/*\n * This is my text. This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.\n *\n * This is another line of text.\n*/"
         val wrappedText = wrapper.wrap(originalText)
-        assertEquals("/*\n * This is my text. This is my long multi-line comment opener text. More text\n * please. This is yet another bunch of text in my test comment, so I will get\n * multiple lines in the comment.\n *\n * This is another line of text.\n*/", wrappedText)
+        assertEquals("/*\n * This is my text. This is my long multi-line comment opener text. More\n * text please. This is yet another bunch of text in my test comment, so I\n * will get multiple lines in the comment.\n *\n * This is another line of text.\n*/", wrappedText)
     }
 
     @Test
     fun testWrapMultipleCommentParagraphs() {
         val originalText = "/*\n * This is my text. This is my long multi-line comment opener text. More text please. This is yet another bunch of text in my test comment, so I will get multiple lines in the comment.\n *\n * This is another line of text.\n * \n * And yet another long line of text. Text going on and an endlessly, much longer than it really should.\n*/"
         val wrappedText = wrapper.wrap(originalText)
-        assertEquals("/*\n * This is my text. This is my long multi-line comment opener text. More text\n * please. This is yet another bunch of text in my test comment, so I will get\n * multiple lines in the comment.\n *\n * This is another line of text.\n * \n * And yet another long line of text. Text going on and an endlessly, much\n * longer than it really should.\n*/", wrappedText)
+        assertEquals("/*\n * This is my text. This is my long multi-line comment opener text. More\n" +
+                " * text please. This is yet another bunch of text in my test comment, so I\n" +
+                " * will get multiple lines in the comment.\n" +
+                " *\n" +
+                " * This is another line of text.\n" +
+                " * \n" +
+                " * And yet another long line of text. Text going on and an endlessly, much\n" +
+                " * longer than it really should.\n" +
+                "*/", wrappedText)
     }
-
 
     @Test
     fun testWrapRetainsSpaceIndent() {
         val text = wrapper.wrap("    This is my long indented string. It's too long to fit on one line, uh oh! What will happen?")
-        val expected = "    This is my long indented string. It's too long to fit on one line, uh oh!\n    What will happen?"
+        val expected = "    This is my long indented string. It's too long to fit on one line,\n    uh oh! What will happen?"
         assertEquals(expected, text)
     }
 
@@ -105,14 +111,14 @@ class CodeWrapperTests {
     @Test
     fun testWrapRemovesExtraBlankLine() {
         val text = wrapper.wrap("\nMy block of text. My block of text. My block of text. My block of text. My block of text. My block of text.")
-        val expected = "My block of text. My block of text. My block of text. My block of text. My block\nof text. My block of text."
+        val expected = "My block of text. My block of text. My block of text. My block of text.\nMy block of text. My block of text."
         assertEquals(expected, text)
     }
 
     @Test
     fun testWrapPreservesLeadingIndent() {
         val text = wrapper.wrap(". My long bullet line. My long bullet line. My long bullet line. My long bullet line.")
-        val expected = ". My long bullet line. My long bullet line. My long bullet line. My long bullet\n. line."
+        val expected = ". My long bullet line. My long bullet line. My long bullet line. My long\n. bullet line."
         assertEquals(expected, text)
     }
 
@@ -126,7 +132,7 @@ class CodeWrapperTests {
     @Test
     fun preservesCommentSymbolsWithinText() {
         val text = wrapper.wrap("/**\n * Let's provide a javadoc comment that has a link to some method, e.g. {@link #m()}.\n */")
-        val expected = "/**\n * Let's provide a javadoc comment that has a link to some method, e.g. {@link\n * #m()}.\n */"
+        val expected = "/**\n * Let's provide a javadoc comment that has a link to some method, e.g.\n * {@link #m()}.\n */"
         assertEquals(expected, text)
     }
 
@@ -158,6 +164,36 @@ class CodeWrapperTests {
     fun testSupportsChinese() {
         val text = wrapper.wrap("它是如何工作的呢？实际上，每个bundle在定义自己的服务配置都是跟目前为止你看到的是一样的。换句话说，一个bundle使用一个或者多个配置资源文件（通常是XML)来指定bundle所需要的参数和服务。然而，我们不直接在配置文件中使用 imports 命令导入它们，而是仅仅在bundle中调用一个服务容器扩展来为我们做同样的工作。一个服务容器扩展是 bundle 的作者创建的一个PHP类，它主要完成两件事情")
         val expected = "它是如何工作的呢？实际上，每个bundle在定义自己的服务配置都是跟目前为止你看到的是一样的。换句话说，一个bundle使用一个或者多个配置资源文件（通常是XML)来指定bundle所需要的参数和服务。然而，我们不直接在配置文件中使用\nimports 命令导入它们，而是仅仅在bundle中调用一个服务容器扩展来为我们做同样的工作。一个服务容器扩展是 bundle\n的作者创建的一个PHP类，它主要完成两件事情"
+        assertEquals(expected, text)
+    }
+
+    @Test
+    fun testTreatHtmlNewlineAsParagraphSeparator() {
+        val text = wrapper.wrap("/**\n" +
+                " * Text on first paragraph.\n" +
+                " * <p>\n" +
+                " * Text on second paragraph. In this case the line is very long and will be wrapped.\n" +
+                " * <br>\n" +
+                " * Third paragraph.\n" +
+                " * <br/>\n" +
+                " * Fourth paragraph.\n" +
+                " * <Br />\n" +
+                " * Fifth paragraph is the last one.\n" +
+                " */")
+
+        val expected = "/**\n" +
+                " * Text on first paragraph.\n" +
+                " * <p>\n" +
+                " * Text on second paragraph. In this case the line is very long and will be\n" +
+                " * wrapped.\n" +
+                " * <br>\n" +
+                " * Third paragraph.\n" +
+                " * <br/>\n" +
+                " * Fourth paragraph.\n" +
+                " * <Br />\n" +
+                " * Fifth paragraph is the last one.\n" +
+                " */";
+
         assertEquals(expected, text)
     }
 }

--- a/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
+++ b/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
@@ -6,7 +6,7 @@ import org.junit.Assert.*
 
 class CodeWrapperTests {
 
-    val wrapper: CodeWrapper = CodeWrapper()
+    private val wrapper: CodeWrapper = CodeWrapper()
 
     @Test
     fun testCreateWithoutOptions() {
@@ -192,7 +192,7 @@ class CodeWrapperTests {
                 " * Fourth paragraph.\n" +
                 " * <Br />\n" +
                 " * Fifth paragraph is the last one.\n" +
-                " */";
+                " */"
 
         assertEquals(expected, text)
     }


### PR DESCRIPTION
After a while my originally intended changes:

- treat `<p>` and `<br>` on a separate line as a paragraph separator

- the width doesn't include the indentation. Rationale: javadoc is offset at
methods or deeply nested classes: we want to wrap the text to a specific width, not
including the indentation and comment start.

- default width changed from 80 to 72: due to the previous point

I recommend to review the commits individually.