### PR TITLE
Fix inline docstring wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ out
 .ropeproject
 .gradle
 build
+.vscode
+bin/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
     implementation(kotlin("stdlib-jdk8"))
 }
 
@@ -32,6 +33,16 @@ tasks {
     }
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
         kotlinOptions.jvmTarget = "17"
+    }
+    withType<Test> {
+        useJUnitPlatform()
+        testLogging {
+            events("failed")
+            exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+        }
     }
 
     patchPluginXml {

--- a/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
@@ -11,21 +11,29 @@ import java.util.regex.Pattern
  * This code was inspired by Nir Soffer's codewrap library: * https://pypi.python.org/pypi/codewrap/
  */
 class CodeWrapper(
-    private val commentRegex: Regex = "(/\\*+|\\*/|\\*|\\.|#+|//+|;+|--|'''|\"\"\"|>)?".toRegex(),
+    private val inlineCommentRegex: Regex = "/\\*+|\\*/|\\*|\\.|#+|//+|;+|--|>".toRegex(),
+    private val docstringRegex: Regex = "\"\"\"|'''".toRegex(),
+    private val commentRegex: Regex = "($inlineCommentRegex)|($docstringRegex)".toRegex(),
 
     private val newlineRegex: Regex = "(\\r?\\n)".toRegex(),
 
     private val htmlSeparatorsRegex: Regex = "<[pP]>|<[bB][rR] ?/?>".toRegex(),
 
-    // A string that contains only two new lines demarcates a paragraph.
-    private val paragraphSeparatorPattern: Pattern = Pattern.compile(
-        "($newlineRegex)\\s*$commentRegex\\s*($htmlSeparatorsRegex)?$newlineRegex"
-    ),
-
     private val tabPlaceholder: String = "☃",
 
-    // A string containing a comment or empty space is considered an indent.
-    private val indentRegex: String = "^(\\s|$tabPlaceholder)*$commentRegex\\s*($htmlSeparatorsRegex)?",
+    private val emptyCommentRegex: Regex = "(\\s|($tabPlaceholder))*($commentRegex)?\\s*($htmlSeparatorsRegex)?".toRegex(),
+
+    // Lines with no contents demarcate paragraphs. This means lines with only
+    // whitespace or commented whitespace.
+    private val paragraphSeparatorPattern: Pattern = Pattern.compile(
+        "($newlineRegex)($emptyCommentRegex)($newlineRegex)"
+    ),
+    private val emptyCommentLinePattern: Pattern = Pattern.compile("^($emptyCommentRegex)$", Pattern.MULTILINE),
+
+    // A string containing an inline comment or empty space is considered an
+    // indent. This indent is determined from the first line and set for all
+    // result lines.
+    private val indentRegex: String = "^(\\s|$tabPlaceholder)*($inlineCommentRegex)?\\s*($htmlSeparatorsRegex)?",
     private val indentPattern: Pattern = Pattern.compile(indentRegex),
 
     // New lines appended to text during wrapping will use this character.
@@ -125,8 +133,7 @@ class CodeWrapper(
      */
     private fun wrapParagraph(paragraph: String): String {
         val resultBuilder = StringBuilder()
-        val emptyCommentPattern = Pattern.compile("$indentRegex\$", Pattern.MULTILINE)
-        val emptyCommentMatcher = emptyCommentPattern.matcher(paragraph)
+        val emptyCommentMatcher = emptyCommentLinePattern.matcher(paragraph)
         val paragraphLength = paragraph.length
         var location = 0
 
@@ -190,19 +197,12 @@ class CodeWrapper(
      */
     private fun breakToLinesOfChosenWidth(text: String): MutableList<String> {
         val firstLineIndent = splitOnIndent(text).indent
-        val firstLineIsDocstring = text.trimStart().matches("^\"\"\"|^'''".toRegex())
-        val firstLineIsCommentOpener = firstLineIndent.matches("\\s*(/\\*+|\"\"\"|''')\\s*".toRegex())
+        val firstLineIsCommentOpener = firstLineIndent.matches("\\s*/\\*+\\s*".toRegex())
         val lines: Array<String>
         var leadingSymbolWidth = 0
         var leadingSymbol = ""
         var width = width
         var correctedText = text
-
-        // Remove docstring symbols from start and end of string
-        if (firstLineIsDocstring) {
-            correctedText = text.replaceFirst("^\"\"\"|^'''".toRegex(), "")
-            correctedText = correctedText.replaceFirst("\"\"\"\$|'''\$".toRegex(), "")
-        }
 
         var unwrappedText = unwrap(correctedText)
 

--- a/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
+++ b/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
@@ -1,6 +1,8 @@
 package com.andrewbrookins.idea.wrap.tests
 
 import org.junit.Test
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
 import org.junit.Assert.*
 import com.andrewbrookins.idea.wrap.*
 
@@ -370,6 +372,28 @@ class CodeWrapperTests {
             """
         ),
         WrapTestCase(
+            "Wraps single line Python docstrings",
+            """
+            ''' This is a long docstring comment. It goes on and on to explain how the function works. However, I forgot to add line breaks! '''
+            """,
+            """
+            ''' This is a long docstring comment. It goes on and on to explain how the
+            function works. However, I forgot to add line breaks! '''
+            """
+        ),
+        WrapTestCase(
+            "Wraps Python docstrings that start on the opener line",
+            """
+            ''' This is a long docstring comment. It goes on and on to explain how the function works. However, I forgot to add line breaks!
+            And the comment continues on the next line. '''
+            """,
+            """
+            ''' This is a long docstring comment. It goes on and on to explain how the
+            function works. However, I forgot to add line breaks! And the comment continues
+            on the next line. '''
+            """
+        ),
+        WrapTestCase(
             "Wraps Markdown block quotes",
             """
             > Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation 
@@ -382,16 +406,27 @@ class CodeWrapperTests {
         )
     )
 
-    @Test
-    fun runAllTests() {
-        testCases.forEach { testCase ->
-            val wrapper = CodeWrapper(
-                tabWidth = testCase.tabWidth,
-                width = testCase.width,
-                useMinimumRaggedness = testCase.useMinimumRaggedness
-            )
-            val result = wrapper.wrap(testCase.input)
-            assertEquals(testCase.description, testCase.expectedOutput, result)
+    @TestFactory
+    fun generateTests(): List<DynamicTest> {
+        return testCases.map { testCase ->
+            DynamicTest.dynamicTest(testCase.description) {
+                val wrapper = CodeWrapper(
+                    tabWidth = testCase.tabWidth,
+                    width = testCase.width,
+                    useMinimumRaggedness = testCase.useMinimumRaggedness
+                )
+                val result = wrapper.wrap(testCase.input)
+                if (testCase.expectedOutput != result) {
+                    // Print the full expected and actual output for easier debugging
+                    fail(
+                        "Test failed for case: ${testCase.description}\n\n" +
+                        "Expected:\n${testCase.expectedOutput}\n\n" +
+                        "Actual:\n$result\n"
+                    )
+                } else {
+                    assertEquals(testCase.description, testCase.expectedOutput, result)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Short docstrings are often put on the same line as their opening and ending sequences. There is no real restriction using this style on multi-line docstrings either, so this formatting style is maintained when a docstring is split into multiple lines - we're not oppressing users with opinionated decisions.

What I'm not fully sure about:
* `paragraphSeparatorPattern` didn't match tab placeholders before, and it seems like it would prevent splitting text into paragraphs, if tabs were used instead of spaces. But this didn't really matter because there isn't an API for wrapping multiple paragraphs?
* [The purpose](https://github.com/abrookins/WrapToColumn/commit/49c4e6b9bc9d31a0051380d30a9bc0ac1a314697) of the `firstLineIsDocstring` hack. If only such docstrings were considered, where the tripple quotes stand on separate lines, `wrapParagraph` would already preseve them as single lines and they'd not enter into `breakToLinesOfChosenWidth`. Maybe some idea for inline docstring handling, I don't understand.