### PR TITLE
Restore old optional column width override setting

### DIFF
--- a/src/main/java/com/andrewbrookins/idea/wrap/config/WrapSettingsState.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/config/WrapSettingsState.kt
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.NotNull
     storages = [Storage("wrap.xml")]
 )
 class WrapSettingsState : PersistentStateComponent<WrapSettingsState> {
+    var doOverrideColumnWidth: Boolean = false
     var columnWidthOverride: Int = 80
     var useMinimumRaggednessAlgorithm: Boolean = false
     var plaintextFileTypes: String = ".md,.markdown,.adoc,.asciidoc,.txt"

--- a/src/main/java/com/andrewbrookins/idea/wrap/ui/WrapSettingsPanel.form
+++ b/src/main/java/com/andrewbrookins/idea/wrap/ui/WrapSettingsPanel.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.andrewbrookins.idea.wrap.ui.WrapSettingsPanel">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="5" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="16" y="20" width="634" height="115"/>
+      <xy x="16" y="20" width="634" height="163"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="e163c" class="javax.swing.JLabel" binding="columnWidthOverrideLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Right margin override:"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="b121e" class="javax.swing.JTextField" binding="columnWidthOverrideField">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="0" anchor="9" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="2" row-span="1" col-span="2" vsize-policy="3" hsize-policy="0" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -30,7 +30,7 @@
       </component>
       <component id="97133" class="javax.swing.JCheckBox" binding="useMinimumRaggednessAlgorithmCheckBox" default-binding="true">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Use minimum raggedness algorithm"/>
@@ -39,7 +39,7 @@
       </component>
       <component id="2abf2" class="javax.swing.JTextField" binding="plaintextFileTypesField">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="2" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -50,7 +50,7 @@
       </component>
       <component id="19610" class="javax.swing.JLabel" binding="plaintextFileTypesLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Plaintext filetypes:"/>
@@ -58,16 +58,25 @@
       </component>
       <hspacer id="655a0">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="158" height="11"/>
           </grid>
         </constraints>
       </hspacer>
       <vspacer id="1cd19">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="b2ea0" class="javax.swing.JCheckBox" binding="doOverrideColumnWidthCheckBox">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Override right margin"/>
+          <toolTipText value="Enabling this will use the value of &quot;Right margin override&quot; to override the default column width when Wrap to Column is run."/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/main/java/com/andrewbrookins/idea/wrap/ui/WrapSettingsPanel.java
+++ b/src/main/java/com/andrewbrookins/idea/wrap/ui/WrapSettingsPanel.java
@@ -22,6 +22,7 @@ public class WrapSettingsPanel {
     private JLabel columnWidthOverrideLabel;
     private JCheckBox useMinimumRaggednessAlgorithmCheckBox;
     private JLabel plaintextFileTypesLabel;
+    private JCheckBox doOverrideColumnWidthCheckBox;
 
     public WrapSettingsPanel() {
         settingsProvider = WrapSettingsState.getInstance();
@@ -32,10 +33,12 @@ public class WrapSettingsPanel {
     }
 
     public boolean isModified() {
+        Boolean doOverrideColumn = settingsProvider.getState().getDoOverrideColumnWidth();
         Integer columnOverride = Objects.requireNonNull(settingsProvider.getState()).getColumnWidthOverride();
         Boolean useMinimumRaggednessAlgorithm = settingsProvider.getState().getUseMinimumRaggednessAlgorithm();
         String plaintextFileTypes = settingsProvider.getState().getPlaintextFileTypes();
-        return !Objects.equals(columnWidthOverrideField.getText(), String.valueOf(columnOverride)) |
+        return !Comparing.equal(doOverrideColumnWidthCheckBox.isSelected(), doOverrideColumn) |
+            !Objects.equals(columnWidthOverrideField.getText(), String.valueOf(columnOverride)) |
             !Objects.equals(plaintextFileTypesField.getText(), plaintextFileTypes) |
             !Comparing.equal(useMinimumRaggednessAlgorithmCheckBox.isSelected(), useMinimumRaggednessAlgorithm);
     }
@@ -50,17 +53,20 @@ public class WrapSettingsPanel {
             columnWidth = null;
         }
 
+        settingsProvider.getState().setDoOverrideColumnWidth(doOverrideColumnWidthCheckBox.isSelected());
         Objects.requireNonNull(settingsProvider.getState()).setColumnWidthOverride(columnWidth);
         settingsProvider.getState().setPlaintextFileTypes(plaintextFileTypesField.getText());
         settingsProvider.getState().setUseMinimumRaggednessAlgorithm(useMinimumRaggednessAlgorithmCheckBox.isSelected());
     }
 
     public void reset() {
+        boolean doOverrideColumn = settingsProvider.getState().getDoOverrideColumnWidth();
         Integer columnOverride = Objects.requireNonNull(settingsProvider.getState()).getColumnWidthOverride();
         boolean useMinimumRaggednessAlgorithm = settingsProvider.getState().getUseMinimumRaggednessAlgorithm();
         String plaintextFileTypes = settingsProvider.getState().getPlaintextFileTypes();
         String overrideText = columnOverride == null ? "" : String.valueOf(columnOverride);
 
+        doOverrideColumnWidthCheckBox.setSelected(doOverrideColumn);
         columnWidthOverrideField.setText(overrideText);
         useMinimumRaggednessAlgorithmCheckBox.setSelected(useMinimumRaggednessAlgorithm);
         plaintextFileTypesField.setText(plaintextFileTypes);

--- a/src/main/java/com/andrewbrookins/idea/wrap/utils.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/utils.kt
@@ -26,15 +26,17 @@ fun isPlaintext(dataContext: DataContext?): Boolean {
 
 
 fun getWrapper(project: Project?, editor: Editor, fileIsPlaintext: Boolean): CodeWrapper {
+    val doOverrideColumnWidth = WrapSettingsState.getInstance().state.doOverrideColumnWidth
     val columnWidthOverride = WrapSettingsState.getInstance().state.columnWidthOverride
     val useMinimumRaggednessAlgorithm = WrapSettingsState.getInstance().state.useMinimumRaggednessAlgorithm ?: false
+    val columnWidth = if (doOverrideColumnWidth) columnWidthOverride else editor.settings.getRightMargin(project)
     val tabWidth = editor.settings.getTabSize(project)
     val wrapper: CodeWrapper
 
 
     if (fileIsPlaintext) {
         wrapper = CodeWrapper(
-            width = columnWidthOverride,
+            width = columnWidth,
             tabWidth = tabWidth,
             useMinimumRaggedness = useMinimumRaggednessAlgorithm,
             commentRegex = "(//)?".toRegex(),
@@ -43,7 +45,7 @@ fun getWrapper(project: Project?, editor: Editor, fileIsPlaintext: Boolean): Cod
 
     } else {
         wrapper = CodeWrapper(
-            width = columnWidthOverride,
+            width = columnWidth,
             tabWidth = tabWidth,
             useMinimumRaggedness = useMinimumRaggednessAlgorithm
         )


### PR DESCRIPTION
This addresses #68 by emulating the old nullable override setting by adding a checkbox that controls whether the setting is enabled or not. Basically I half-implemented the suggestion from https://github.com/abrookins/WrapToColumn/issues/68#issuecomment-2816824403.

Forgive me if the impl is a bit rough. This is my first ever time touching Kotlin or IntelliJ plugins, and my first time in ~10 years touching Java or Swing, so I might be a _bit_ rusty! I did my best to maintain the same look & feel of the existing form, had to fiddle with alignment a bit. 

I don't know how best to disable the column override text field when the checkbox is not selected. If you want to give some direction on how you'd like to see it implemented I'd be happy to take a stab at it, otherwise I'll leave it to you.

I threw this together for my own use, figured I'd put up a PR in case you want to take this direction instead of trying to get nullable values working again.