### PR TITLE
Wrap Rust parent line comments

### DIFF
--- a/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
+++ b/src/main/java/com/andrewbrookins/idea/wrap/CodeWrapper.kt
@@ -11,7 +11,7 @@ import java.util.regex.Pattern
  * This code was inspired by Nir Soffer's codewrap library: * https://pypi.python.org/pypi/codewrap/
  */
 class CodeWrapper(
-    private val commentRegex: Regex = "(/\\*+|\\*/|\\*|\\.|#+|//+|;+|--|'''|\"\"\"|>)?".toRegex(),
+    private val commentRegex: Regex = "(/\\*+|\\*/|\\*|\\.|#+|//+!?|;+|--|'''|\"\"\"|>)?".toRegex(),
 
     private val newlineRegex: Regex = "(\\r?\\n)".toRegex(),
 

--- a/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
+++ b/src/test/java/com/andrewbrookins/idea/wrap/CodeWrapperTest.kt
@@ -379,6 +379,20 @@ class CodeWrapperTests {
             > incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
             > nostrud exercitation
             """
+        ),
+        WrapTestCase(
+            description = "Wraps Rust parent line comments",
+            rawInput = """
+            //! My foo module
+            //!
+            //! This is the documentation for my foo module. It has some pretty long lines, which I consider a feature and not a bug.
+            """,
+            rawExpectedOutput = """
+            //! My foo module
+            //!
+            //! This is the documentation for my foo module. It has some pretty long lines,
+            //! which I consider a feature and not a bug.
+            """
         )
     )
 


### PR DESCRIPTION
Implements #52. Manually tested in RustRover 2025.1.3.