### PR TITLE
Release 1.9.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.andrewbrookins.idea.wrap"
-version = "1.9.3"
+version = "1.9.4"
 
 repositories {
     mavenCentral()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>com.andrewbrookins.wrap_to_column</id>
   <name>Wrap to Column</name>
-  <version>1.9.3</version>
+  <version>1.9.4</version>
   <vendor email="a@andrewbrookins.com" url="http://andrewbrookins.com">Andrew Brookins</vendor>
 
   <description><![CDATA[
@@ -33,6 +33,13 @@
       ]]></description>
 
   <change-notes><![CDATA[
+    <b>1.9.4</b>
+    <ul>
+    <li>Fixed wrapping for comments with tab indentation. (Issue #73, thanks @Grimeh!)</li>
+    <li>Fixed inline comments adding extraneous newlines. (Issue #74, thanks @Grimeh!)</li>
+    <li>Fixed selections ending with multiple newlines adding an extra newline.</li>
+    </ul>
+
     <b>1.9.3</b>
     <ul>
     <li>Fixed a bug where wrapping code with inline comments would remove comment markers from continuation lines. (Issue #72, thanks @edgarsi!)</li>


### PR DESCRIPTION
## What's Changed

- Fixed wrapping for comments with tab indentation (#73)
- Fixed inline comments adding extraneous newlines (#74)
- Fixed selections ending with multiple newlines adding an extra newline

Thanks to @Grimeh for the fix\!

**Full Changelog**: https://github.com/abrookins/WrapToColumn/compare/1.9.3...1.9.4
